### PR TITLE
fix: binary is named standalone, not backend

### DIFF
--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,3 +1,3 @@
 FROM scratch
-COPY backend /backend
-ENTRYPOINT ["/backend"]
+COPY standalone /standalone
+ENTRYPOINT ["/standalone"]


### PR DESCRIPTION
This is a copy-paste error that happenend when using the backend repository as template.
