### PR TITLE
chore(deps): fix renovate ldflags config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,7 +37,7 @@
       "description": "Upgrade backend version in ldflags",
       "fileMatch": ["^\\.goreleaser.yaml", "Makefile"],
       "matchStrings": [
-        "-X github.com/envelope-zero/backend/pkg/router.version=(?<currentValue>[^\"]*)\"?$"
+        "-X github.com/envelope-zero/backend/pkg/router\\.version=(?<currentValue>\\d+\\.\\d+\\.\\d+)"
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "envelope-zero/backend"


### PR DESCRIPTION
This should make renovate detect the ldflags setting strings, too.
