### PR TITLE
chore(deps): add datasource match for backend versioning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,6 +54,7 @@
     {
       "description": "Remove v from backend version as it is used in the API version",
       "matchPackageNames": ["envelope-zero/backend"],
+      "matchDatasources": ["github-releases"],
       "extractVersion": "^v(?<version>)"
     },
     {


### PR DESCRIPTION
This might fix renovate not finding any results in the datasource with 

```
DEBUG: Found no results from datasource that look like a version (envelope-zero/backend)(dependency="envelope-zero/backend")
```
