### PR TITLE
fix: embed frontend in binary

### DIFF
--- a/.github/actions/go-test/action.yml
+++ b/.github/actions/go-test/action.yml
@@ -16,4 +16,5 @@ runs:
     - name: Run go tests
       shell: bash
       run: |
+        make frontend
         go test ./... -race -covermode=atomic

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,11 @@ issues:
         - errcheck
         - dupl
 
+    - path: main.go
+      linters:
+        - typecheck
+      text: "pattern public: no matching files found"
+
 linters:
   enable:
     - gocyclo

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,6 +11,10 @@ builds:
     ldflags:
       - -X github.com/envelope-zero/backend/pkg/router.version=1.0.2
 
+    # Extract the frontend files so that we can embed them
+    hooks:
+      pre: make frontend
+
 archives:
   - replacements:
       amd64: x86_64

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "cwd": "${workspaceFolder}",
+      "program": "${workspaceFolder}/main.go",
+      "console": "integratedTerminal"
+    }
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ setup: setup-pre-commit-ci
 	go install github.com/cosmtrek/air@latest
 
 .PHONY: devserver
-devserver:
+devserver: frontend
 	GIN_MODE=debug air
 
 .PHONY: test


### PR DESCRIPTION
With this, the frontend files are embedded into the binary, making it 100% portable.
