### PR TITLE
fix: extract frontend before running goreleaser

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -39,12 +39,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install GoReleaser
+      - name: Extract frontend files
+        run: make frontend
+
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
-          install-only: true
-
-      - name: Release
-        run: goreleaser release --rm-dist
+          version: latest
+          args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,10 +11,6 @@ builds:
     ldflags:
       - -X github.com/envelope-zero/backend/pkg/router.version=1.0.2
 
-    # Extract the frontend files so that we can embed them
-    hooks:
-      pre: make frontend
-
 archives:
   - replacements:
       amd64: x86_64


### PR DESCRIPTION
This reverts commit 4125a6f58974ec12c8587cecad35d901cba3189c and
extracts the frontend files before running goreleaser instead.
