### PR TITLE
chore(renovate): fix commit message prefix for breaking changes

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -113,7 +113,7 @@
         "envelope-zero/backend",
         "github.com/envelope-zero/backend"
       ],
-      "commitMessagePrefix": "feat!(backend):"
+      "commitMessagePrefix": "feat(backend)!:"
     },
     {
       "description": "Bump patch version for frontend patch updates",
@@ -131,7 +131,7 @@
       "description": "Bump major version for frontend major updates",
       "matchUpdateTypes": ["major"],
       "matchPackageNames": ["ghcr.io/envelope-zero/frontend"],
-      "commitMessagePrefix": "feat!(frontend):"
+      "commitMessagePrefix": "feat(frontend)!:"
     }
   ]
 }


### PR DESCRIPTION
The `!` belongs behind the topic.
