### PR TITLE
test: verify that binary runs

### DIFF
--- a/.github/actions/go-test/action.yml
+++ b/.github/actions/go-test/action.yml
@@ -18,3 +18,11 @@ runs:
       run: |
         make frontend
         go test ./... -race -covermode=atomic
+
+      # This builds the binary and starts it. If it does not exit within 3 seconds, consider it
+      # successful
+    - name: Verify binary works
+      shell: bash
+      run: |
+        make build
+        timeout 3 ./standalone || code=$?; if [[ $code -ne 124 && $code -ne 0 ]]; then exit $code; fi


### PR DESCRIPTION
This verifies that the built binary can run successfully. 

It will prevent errors in relation to the app startup.
