### PR TITLE
chore(renovate): also match major releases of the backend after v1 in the group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "dependencyDashboard": true,
   "pre-commit": {
     "enabled": true
@@ -91,6 +92,7 @@
         "envelope-zero/backend",
         "github.com/envelope-zero/backend"
       ],
+      "matchPackagePatterns": ["github.com/envelope-zero/backend/v.*"],
       "groupName": "backend"
     },
     {


### PR DESCRIPTION
Go major versioning after v1 is funny and therefore it's a new package. Adding it to the group with this change.
