### PR TITLE
fix: remove outdated config option for goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,10 +11,6 @@ builds:
     ldflags:
       - -X github.com/envelope-zero/backend/pkg/router.version=3.0.0
 
-archives:
-  - replacements:
-      amd64: x86_64
-
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 


### PR DESCRIPTION
This removes a config option for goreleaser that is no longer available
